### PR TITLE
勤怠一覧のUI修正

### DIFF
--- a/webapps/config/schema/create_table.sql
+++ b/webapps/config/schema/create_table.sql
@@ -224,3 +224,10 @@ CREATE TABLE time_card_states (
 ALTER TABLE employee_salaries CHANGE updated modified datetime NOT NULL;
 ALTER TABLE employee_time_cards CHANGE updated modified datetime NOT NULL;
 ALTER TABLE time_card_states CHANGE updated modified datetime NOT NULL;
+
+ALTER TABLE employee_time_cards ADD round_start_time TIME AFTER end_time;
+ALTER TABLE employee_time_cards ADD round_end_time TIME AFTER round_start_time;
+
+-- TODO: いつか実行
+-- ALTER TABLE employee_time_cards drop column break_start_time;
+-- ALTER TABLE employee_time_cards drop column break_end_time;

--- a/webapps/src/Controller/EmployeeTimeCardsController.php
+++ b/webapps/src/Controller/EmployeeTimeCardsController.php
@@ -118,7 +118,9 @@ class EmployeeTimeCardsController extends AppController
 
         /** @var \App\Model\Table\EmployeesTable $Employees */
         $Employees = TableRegistry::get('Employees');
-        $employee = $Employees->get($employeeId);
+        $employee = $Employees->get($employeeId, ['contain' => ['EmployeeSalaries']]);
+
+        $this->log($employee);
 
         // 編集は1分単位で
         $times = $this->TimeCard->buildTimes($this->UserAuth->currentStore());

--- a/webapps/src/Controller/EmployeeTimeCardsController.php
+++ b/webapps/src/Controller/EmployeeTimeCardsController.php
@@ -116,6 +116,10 @@ class EmployeeTimeCardsController extends AppController
         $next = date('Ym', strtotime(date('Y-m-1', $target). ' +1 month'));
         $prev = date('Ym', strtotime(date('Y-m-1', $target). ' -1 month'));
 
+        /** @var \App\Model\Table\EmployeesTable $Employees */
+        $Employees = TableRegistry::get('Employees');
+        $employee = $Employees->get($employeeId);
+
         // 編集は1分単位で
         $times = $this->TimeCard->buildTimes($this->UserAuth->currentStore());
         $oneStepTimes = $this->TimeCard->buildTimes($this->UserAuth->currentStore(), 1);

--- a/webapps/src/Controller/EmployeeTimeCardsController.php
+++ b/webapps/src/Controller/EmployeeTimeCardsController.php
@@ -200,8 +200,10 @@ class EmployeeTimeCardsController extends AppController
             $employeeId = $data['employeeId'];
             $path = $data['path'];
             $time = $data['time'];
+            $additions = [];
+            $additions['break_minute'] = $data['break_minute'];
 
-            $result = $this->EmployeeTimeCards->write($this->storeId, $employeeId, $path, $time);
+            $result = $this->EmployeeTimeCards->write($this->storeId, $employeeId, $path, $time, $additions);
 
             $this->log($result);
             echo json_encode(['success' => $result]);

--- a/webapps/src/Template/EmployeeTimeCards/index.ctp
+++ b/webapps/src/Template/EmployeeTimeCards/index.ctp
@@ -79,7 +79,7 @@ echo $this->Html->script($base.'/lib/moment.min.js');
          * 次月、前月クリック時
          */
         $(document).on('click', '.pagination a', function(e) {
-            var employeeId = $('#employee-list').find('.current').data('id');
+            var employeeId = $('#employee-list').val();
             var target = $(this).data('target');
             loadTimeCardTable(employeeId, target);
             return false;

--- a/webapps/src/Template/EmployeeTimeCards/index.ctp
+++ b/webapps/src/Template/EmployeeTimeCards/index.ctp
@@ -22,36 +22,31 @@
         color: #3a87ad;
     }
 </style>
+
 <div class="row">
     <?php // 従業員エリア ?>
-    <div class="col-md-2">
+    <div class="col-md-12">
         <div class="box-inner">
             <div class="box-header well" data-original-title="">
                 <h2><i class="glyphicon glyphicon-user"></i> 従業員一覧</h2>
             </div>
             <div class="box-content">
-                <table id="employee-list" class="table responsive">
-                    <thead>
-                    <tr>
-                        <th>苗字</th>
-                    </tr>
-                    </thead>
-                    <tbody>
+                <select id="employee-list" class="form-control">
+                    <option value=""></option>
                     <?php foreach ($employees as $employee) :?>
-                        <tr class="employee-row" data-id="<?= $employee->id ?>">
-                            <td>
-                                <?= $employee->last_name; ?>
-                            </td>
-                        </tr>
+                        <option value="<?= $employee->id ?>">
+                            <?= trim($employee->last_name).' '.trim($employee->first_name); ?>
+                        </option>
                     <?php endforeach; ?>
-                    </tbody>
-                </table>
+                </select>
             </div>
         </div>
     </div>
+</div>
 
+<div class="row">
     <?php // 勤務表エリア ?>
-    <div class="col-md-10">
+    <div class="box col-md-12">
         <div class="box-inner">
             <div class="box-header well" data-original-title="">
                 <h2><i class="glyphicon glyphicon-book"></i> 月別勤務表</h2>
@@ -72,15 +67,12 @@ echo $this->Html->script($base.'/lib/moment.min.js');
 <script type="text/javascript">
     $(function() {
         var DATE_FORMAT = 'YYYYMM';
-
         /**
-         * 従業員行クリック時
+         * 従業員選択時
          */
-        $(document).on('click', '.employee-row', function(e) {
+        $(document).on('change', '#employee-list', function(e) {
             e.preventDefault();
-            $('.employee-row').removeClass('current');
-            $(this).addClass('current');
-            loadTimeCardTable($(this).data('id'), moment().format(DATE_FORMAT));
+            loadTimeCardTable($(this).val(), moment().format(DATE_FORMAT));
         });
 
         /**

--- a/webapps/src/Template/EmployeeTimeCards/index.ctp
+++ b/webapps/src/Template/EmployeeTimeCards/index.ctp
@@ -90,14 +90,14 @@ echo $this->Html->script($base.'/lib/moment.min.js');
          */
         $(document).on('click', '.editable-button a', function(e) {
             var $this = $(this);
-            $('.time-label').show();
-            $('.time-input').hide();
+            $('.editable-label').show();
+            $('.editable-input').hide();
             $('.editable-button').show();
             $('.editable-actions').hide();
 
             var $parent = $this.parents('.time-row');
-            $parent.find('.time-label').hide();
-            $parent.find('.time-input').show();
+            $parent.find('.editable-label').hide();
+            $parent.find('.editable-input').show();
 
             $parent.find('.editable-button').hide();
             $parent.find('.editable-actions').show();
@@ -108,8 +108,8 @@ echo $this->Html->script($base.'/lib/moment.min.js');
          * 編集取消クリック時
          */
         $(document).on('click', '.editable-actions .cancel', function(e) {
-            $('.time-label').show();
-            $('.time-input').hide();
+            $('.editable-label').show();
+            $('.editable-input').hide();
             $('.editable-button').show();
             $('.editable-actions').hide();
             return false;
@@ -122,12 +122,12 @@ echo $this->Html->script($base.'/lib/moment.min.js');
             var $this = $(this);
             var $parent = $this.parents('.time-row');
             var ymd = $parent.data('ymd');
-            var employeeId = $('#employee-list').find('.current').data('id');
+            var employeeId = $('#employee-list').val();
 
             var data = {};
-            $parent.find('.time-input').each(function() {
-                var $s = $(this).find('select');
-                data[$s.data('path')] = $s.val();
+            $parent.find('.editable-input').each(function() {
+                var $s = $(this).find('.item');
+                data[$s.attr('name')] = $s.val();
             });
 
             var parameter = {

--- a/webapps/src/Template/EmployeeTimeCards/input.ctp
+++ b/webapps/src/Template/EmployeeTimeCards/input.ctp
@@ -203,16 +203,9 @@ echo $this->Html->script($base.'/lib/moment.min.js');
                 ],
                 '/start': [
                     '/end',
-                    '/break/start'
                 ],
                 '/end': [
                     '/start'
-                ],
-                '/break/start': [
-                    '/break/end'
-                ],
-                '/break/end': [
-                    '/end'
                 ]
             };
 

--- a/webapps/src/Template/EmployeeTimeCards/input.ctp
+++ b/webapps/src/Template/EmployeeTimeCards/input.ctp
@@ -53,6 +53,11 @@
             </div>
             <div class="modal-body">
                 <h2 id="clock"></h2>
+                <div id="break-input-area" class="box center-block" style="display: none;">
+                    休憩時間：
+                    <input id="break-time" type="text" name="break_minute"
+                           value="15" class="form-control" style="width: 50%; display: inline-block;">
+                </div>
             </div>
             <div class="modal-footer center">
                 <?php foreach ($states as $state): ?>
@@ -111,7 +116,8 @@ echo $this->Html->script($base.'/lib/moment.min.js');
                 token: $('#token').val(),
                 employeeId: $('#employee-id').val(),
                 path: $(this).data('path'),
-                time: moment().format('YYYY-MM-DD HH:mm:ss')
+                time: moment().format('YYYY-MM-DD HH:mm:ss'),
+                break_minute: $('#break-time').val()
             };
             console.log(parameter);
             $.ajax({
@@ -179,6 +185,7 @@ echo $this->Html->script($base.'/lib/moment.min.js');
             $(buttonSelector).each(function() {
                 if (0 <= $.inArray($(this).data('path'), showButtons)) {
                     $(this).css('display', 'inline-block');
+                    $('#break-input-area').css('display', ($(this).data('path') === '/end') ? 'block' : 'none');
                 }
             });
         }

--- a/webapps/src/Template/EmployeeTimeCards/table.ctp
+++ b/webapps/src/Template/EmployeeTimeCards/table.ctp
@@ -5,11 +5,26 @@
     .time-input input {
         height: 30px;
     }
+    table th {
+        text-align: center;
+    }
 </style>
 
-<h3 class="center-block">
-    <?= $showMonth ?>
-</h3>
+<table class="table-bordered responsive">
+    <thead>
+    <tr>
+        <th>年月</th>
+        <th>氏名</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td><?= $showMonth ?></td>
+        <td><?= trim($employee->last_name).' '.trim($employee->first_name); ?></td>
+    </tr>
+    </tbody>
+</table>
+
 <ul class="pagination col-md-12">
     <li id="prev" style="float: left;">
         <a href="#" data-target="<?= $prev ?>">&lt; 前月</a>
@@ -22,14 +37,21 @@
 <table class="table table-bordered responsive">
     <thead>
     <tr>
-        <th>日付</th>
-        <th>開始時間</th>
-        <th>終了時間</th>
-        <th>休憩開始</th>
-        <th>休憩終了</th>
-        <th>総労働時間</th>
-        <th>実労働時間</th>
-        <th>操作</th>
+        <th rowspan="2">日付</th>
+        <th colspan="2">タイムカード</th>
+        <th colspan="2">実時刻</th>
+        <th colspan="4">当日集約</th>
+        <th rowspan="2">操作</th>
+    </tr>
+    <tr>
+        <th>出勤</th>
+        <th>退勤</th>
+        <th>始業</th>
+        <th>終業</th>
+        <th>総労働(時.分)</th>
+        <th>休憩(分)</th>
+        <th>実労働(時.分)</th>
+        <th>時給(円)</th>
     </tr>
     </thead>
     <tbody>
@@ -63,19 +85,29 @@
                     <td>
                         <?= $this->TimeCard->editableTime($oneStepTimes, $data['end_time'], '/end'); ?>
                     </td>
+                    <?php // TODO: ?>
                     <td>
-                        <?= $this->TimeCard->editableTime(
-                            $oneStepTimes, $data['break_start_time'], '/break/start'); ?>
+                        <?= $this->TimeCard->editableTime($oneStepTimes, $data['start_time'], '/start'); ?>
                     </td>
                     <td>
-                        <?= $this->TimeCard->editableTime(
-                            $oneStepTimes, $data['break_end_time'], '/break/end'); ?>
+                        <?= $this->TimeCard->editableTime($oneStepTimes, $data['end_time'], '/end'); ?>
                     </td>
+
                     <td>
                         <?= $this->TimeCard->formatHour($data['work_minute']); ?>
                     </td>
+
+                    <?php // TODO: ?>
+                    <td>
+                        <?= 10; ?>
+                    </td>
+
                     <td>
                         <?= $this->TimeCard->formatHour($data['real_minute']); ?>
+                    </td>
+
+                    <td>
+                        <?= h($data['hour_pay']); ?>
                     </td>
                     <td>
                         <?php // 編集ボタンを押したら、更新部分が表示されます. ?>
@@ -105,6 +137,14 @@
                     <td>
                         <?= $this->TimeCard->editableTime($times, '', '/end'); ?>
                     </td>
+                    <?php // TODO: ?>
+                    <td>
+                        <?= $this->TimeCard->editableTime($times, '', '/start'); ?>
+                    </td>
+                    <td>
+                        <?= $this->TimeCard->editableTime($times, '', '/end'); ?>
+                    </td>
+
                     <td>
                         <?= $this->TimeCard->editableTime($times, '', '/break/start'); ?>
                     </td>

--- a/webapps/src/Template/EmployeeTimeCards/table.ctp
+++ b/webapps/src/Template/EmployeeTimeCards/table.ctp
@@ -1,9 +1,16 @@
 <style>
-    .time-input {
+    .editable-input {
         display: none;
     }
-    .time-input input {
+    .editable-input input
+    {
         height: 30px;
+        width: 4em;
+    }
+    .editable-input select
+    {
+        height: 30px;
+        width: 5em;
     }
     table th {
         text-align: center;
@@ -48,9 +55,9 @@
         <th>退勤</th>
         <th>始業</th>
         <th>終業</th>
-        <th>総労働(時.分)</th>
+        <th>総労働</th>
         <th>休憩(分)</th>
-        <th>実労働(時.分)</th>
+        <th>実労働</th>
         <th>時給(円)</th>
     </tr>
     </thead>
@@ -131,28 +138,24 @@
                         <?php endif; ?>
                     </td>
                 <?php else: ?>
+                    <td></td>
+                    <td></td>
                     <td>
-                        <?= $this->TimeCard->editableTime($times, '', '/start'); ?>
+                        <?= $this->TimeCard->editableTime($times, '', 'round_start_time'); ?>
                     </td>
                     <td>
-                        <?= $this->TimeCard->editableTime($times, '', '/end'); ?>
-                    </td>
-                    <?php // TODO: ?>
-                    <td>
-                        <?= $this->TimeCard->editableTime($times, '', '/start'); ?>
-                    </td>
-                    <td>
-                        <?= $this->TimeCard->editableTime($times, '', '/end'); ?>
+                        <?= $this->TimeCard->editableTime($times, '', 'round_end_time'); ?>
                     </td>
 
-                    <td>
-                        <?= $this->TimeCard->editableTime($times, '', '/break/start'); ?>
-                    </td>
-                    <td>
-                        <?= $this->TimeCard->editableTime($times, '', '/break/end'); ?>
-                    </td>
                     <td></td>
+                    <td><?= $this->TimeCard->editableText(15, 'break_minute', ['label' => false]); // TODO: 設定ファイル ?></td>
                     <td></td>
+                    <td>
+                        <?php
+                            $amount = empty($employee->employee_salary) ? 0 : $employee->employee_salary->amount;
+                            echo $this->TimeCard->editableText($amount, 'hour_pay', ['label' => false]);
+                        ?>
+                    </td>
                     <td>
                         <?php // 追加ボタンを押したら、更新部分が表示されます. ?>
                         <?php if ($canEdit) :?>

--- a/webapps/src/Template/EmployeeTimeCards/table.ctp
+++ b/webapps/src/Template/EmployeeTimeCards/table.ctp
@@ -86,36 +86,14 @@
                     <?php
                         $data = $records[$ymd];
                     ?>
-                    <td>
-                        <?= $this->TimeCard->editableTime($oneStepTimes, $data['start_time'], '/start'); ?>
-                    </td>
-                    <td>
-                        <?= $this->TimeCard->editableTime($oneStepTimes, $data['end_time'], '/end'); ?>
-                    </td>
-                    <?php // TODO: ?>
-                    <td>
-                        <?= $this->TimeCard->editableTime($oneStepTimes, $data['start_time'], '/start'); ?>
-                    </td>
-                    <td>
-                        <?= $this->TimeCard->editableTime($oneStepTimes, $data['end_time'], '/end'); ?>
-                    </td>
-
-                    <td>
-                        <?= $this->TimeCard->formatHour($data['work_minute']); ?>
-                    </td>
-
-                    <?php // TODO: ?>
-                    <td>
-                        <?= 10; ?>
-                    </td>
-
-                    <td>
-                        <?= $this->TimeCard->formatHour($data['real_minute']); ?>
-                    </td>
-
-                    <td>
-                        <?= h($data['hour_pay']); ?>
-                    </td>
+                    <td><?= $this->TimeCard->formatTime($data['start_time']); ?></td>
+                    <td><?= $this->TimeCard->formatTime($data['end_time']); ?></td>
+                    <td><?= $this->TimeCard->editableTime($times, $data['round_start_time'], 'round_start_time'); ?></td>
+                    <td><?= $this->TimeCard->editableTime($times, $data['round_end_time'], 'round_end_time'); ?></td>
+                    <td><?= $this->TimeCard->formatHour($data['work_minute']); ?></td>
+                    <td><?= $this->TimeCard->editableText($data['break_minute'], 'break_minute');?></td>
+                    <td><?= $this->TimeCard->formatHour($data['real_minute']); ?></td>
+                    <td><?= $this->TimeCard->editableText($data['hour_pay'], 'hour_pay'); ?></td>
                     <td>
                         <?php // 編集ボタンを押したら、更新部分が表示されます. ?>
                         <?php if ($canEdit) :?>
@@ -140,13 +118,8 @@
                 <?php else: ?>
                     <td></td>
                     <td></td>
-                    <td>
-                        <?= $this->TimeCard->editableTime($times, '', 'round_start_time'); ?>
-                    </td>
-                    <td>
-                        <?= $this->TimeCard->editableTime($times, '', 'round_end_time'); ?>
-                    </td>
-
+                    <td><?= $this->TimeCard->editableTime($times, '', 'round_start_time'); ?></td>
+                    <td><?= $this->TimeCard->editableTime($times, '', 'round_end_time'); ?></td>
                     <td></td>
                     <td><?= $this->TimeCard->editableText(15, 'break_minute', ['label' => false]); // TODO: 設定ファイル ?></td>
                     <td></td>

--- a/webapps/src/View/Helper/TimeCardHelper.php
+++ b/webapps/src/View/Helper/TimeCardHelper.php
@@ -57,23 +57,49 @@ class TimeCardHelper extends Helper {
      * 勤怠一覧の編集可能時間エリア
      * @param $times array 選択可能時間 Componentで構築したもの.
      * @param $value string 現在の値
-     * @param $path string 勤怠状態のエイリアス
+     * @param $name string 指定するname
      * @return string タグ
      */
-    public function editableTime($times, $value, $path) {
+    public function editableTime($times, $value, $name) {
         $tagFormat = '
-            <span class="time-label">
+            <span class="editable-label">
                 %s
             </span>
-            <span class="time-input">
-                <select data-path="%s" class="form-control" style="height: 30px; width: auto;">
+            <span class="editable-input">
+                <select name="%s" class="item" class="form-control">
                     %s
                 </select>
             </span>
         ';
         $value = $this->formatTime($value);
-        $values = [$value, $path, $this->buildTimeOptions($times, $value)];
+        $values = [$value, $name, $this->buildTimeOptions($times, $value)];
         return vsprintf($tagFormat, $values);
+    }
+
+    /**
+     * テキスト入力切り替え可能なラベルを出力します.
+     *
+     * @param $value string|int 現在の値
+     * @param $name string input属性に指定するname
+     * @param $showValue array 値を表示させたい項目. labelだけとかできるように.
+     * @return string HTMLタグ
+     */
+    public function editableText($value, $name, array $showValue = []) {
+        $tagFormat = '
+            <span class="editable-label">
+                %s
+            </span>
+            <span class="editable-input">
+                <input type="text" class="item" value="%s" name="%s" />
+            </span>
+        ';
+        $showValue = array_merge(['label' => true, 'input' => true], $showValue);
+        $values = [];
+        $values[] = empty($showValue['label']) ? ' ' : $value;
+        $values[] = empty($showValue['input']) ? ' ' : $value;
+        $values[] = $name;
+        return vsprintf($tagFormat, $values);
+
     }
 
     /**


### PR DESCRIPTION
・15分単位で時間をまるめるように修正。総労働時間などはこれを見て計算する。
・休憩時間のタイムカードをなくして、手入力にしてもらう
　→UI的にも面倒ではないというか、こちらのほうが楽かも
・勤怠一覧のUI一新。タイムカードと実時刻（まるめたの）を分けて表示