### PR TITLE
シフト作成に関するバグフィックス

### DIFF
--- a/webapps/src/Template/Element/Calendar/assets.ctp
+++ b/webapps/src/Template/Element/Calendar/assets.ctp
@@ -11,3 +11,20 @@ echo $this->Html->script($base.'/lib/moment.min.js');
 echo $this->Html->script($base.'/lib/fullcalendar.min.js');
 echo $this->Html->script($base.'/scheduler.min.js');
 echo $this->Html->script(CHARISMA_BOWER.'/fullcalendar/dist/lang-all.js');
+
+?>
+
+<style>
+    .fc-timeline-event .fc-content {
+        white-space: pre-line;
+    }
+    .fc-rows td.fc-widget-content div,
+    .fc-content td.fc-widget-content div,
+    .fc-event-container {
+        height: 40px !important;
+    }
+    .fc-timeline-event,
+    .fc-timeline-event .fc-time {
+        padding: 0;
+    }
+</style>

--- a/webapps/src/Template/FixedShiftTables/view.ctp
+++ b/webapps/src/Template/FixedShiftTables/view.ctp
@@ -32,6 +32,10 @@
         max-width: 1200px;
         margin: 20px auto;
     }
+    .fc-time-area col {
+        max-width: 2.2em;
+        min-width: 43px;
+    }
 </style>
 
 <script>

--- a/webapps/src/Template/FixedShiftTables/view.ctp
+++ b/webapps/src/Template/FixedShiftTables/view.ctp
@@ -32,9 +32,6 @@
         max-width: 1200px;
         margin: 20px auto;
     }
-    .fc-timeline-event .fc-content {
-        white-space: pre-line;
-    }
 </style>
 
 <script>

--- a/webapps/src/Template/FixedShiftTables/view.ctp
+++ b/webapps/src/Template/FixedShiftTables/view.ctp
@@ -41,9 +41,16 @@
 
     $(function() {
         $('#fix-shift-table').fullCalendar({
+            schedulerLicenseKey: 'CC-Attribution-NonCommercial-NoDerivatives',
             now: '<?= date('Y-m-d', strtotime($data['target_ym'].'01')); ?>',
             header: {
                 right: false
+            },
+            slotLabelFormat: {
+                month: [
+                    'D',
+                    'ddd'
+                ]
             },
             editable: false,
             lang: 'ja',

--- a/webapps/src/Template/ShiftTables/edit.ctp
+++ b/webapps/src/Template/ShiftTables/edit.ctp
@@ -261,7 +261,8 @@ $resources = json_encode($resources);
             },
             slotLabelFormat: {
                 month: [
-                    'D ddd'
+                    'D',
+                    'ddd'
                 ],
                 day: [
                     'H:mm'

--- a/webapps/src/Template/ShiftTables/edit.ctp
+++ b/webapps/src/Template/ShiftTables/edit.ctp
@@ -21,9 +21,6 @@ $resources = json_encode($resources);
 <?= $this->element('Notice/show_top', ['message' => 'シフトを一時保存しました']); ?>
 
 <style>
-    .fc-timeline-event .fc-content {
-        white-space: pre-line;
-    }
     .fc-timelineMonth-view  .fc-time-area .fc-widget-header .fc-cell-text {
         cursor: pointer;
     }

--- a/webapps/src/Template/ShiftTables/edit.ctp
+++ b/webapps/src/Template/ShiftTables/edit.ctp
@@ -24,7 +24,7 @@ $resources = json_encode($resources);
     .fc-timeline-event .fc-content {
         white-space: pre-line;
     }
-    .fc-timelineMonth-view .fc-cell-text{
+    .fc-timelineMonth-view  .fc-time-area .fc-widget-header .fc-cell-text {
         cursor: pointer;
     }
 </style>
@@ -230,8 +230,10 @@ $resources = json_encode($resources);
 
         /**
          * 月表示から詳細を見れるように.
+         * 同じセレクタでスタイルも上部に定義済み.
          */
-        $(document).on('click', '.fc-timelineMonth-view .fc-cell-text', function() {
+        $(document).on('click',
+            '.fc-timelineMonth-view  .fc-time-area .fc-widget-header .fc-cell-text', function() {
             var $calendar = $(calendarSelector);
             var date = $calendar.fullCalendar('getDate');
             // FIXME: フォーマット変わったらマズイ
@@ -261,8 +263,7 @@ $resources = json_encode($resources);
             },
             slotLabelFormat: {
                 month: [
-                    'D',
-                    'ddd'
+                    'D ddd'
                 ],
                 day: [
                     'H:mm'


### PR DESCRIPTION
・従業員名をクリックすると不正な動きをする
・シフトを入れた時の変な隙間を無くす
・確定シフトの時は印刷、PDF生成に備えて、日付と曜日が縦になるように修正