### PR TITLE
別店舗の確定シフトも消えてしまう件の対応

### DIFF
--- a/webapps/src/Controller/ShiftTablesController.php
+++ b/webapps/src/Controller/ShiftTablesController.php
@@ -69,7 +69,7 @@ class ShiftTablesController extends AppController
 
             /** @var \App\Model\Table\FixedShiftTablesTable $FixedShiftTables */
             $FixedShiftTables = TableRegistry::get('FixedShiftTables');
-            $FixedShiftTables->removeAllByTargetYm($targetYm);
+            $FixedShiftTables->reset($storeId, $targetYm);
 
             $body = $this->buildBody($shift);
             $result = $this->ShiftTables->patch($storeId, $targetYm, $body)

--- a/webapps/src/Model/Table/FixedShiftTablesTable.php
+++ b/webapps/src/Model/Table/FixedShiftTablesTable.php
@@ -83,16 +83,19 @@ class FixedShiftTablesTable extends Table
     }
 
     /**
-     * 指定された年月のシフトを全て削除します.
+     * 同じ月で複数の確定シフトが出ないよう、
+     * 同年月のシフトを全て削除します.
      *
+     * @param $storeId int 店舗ID
      * @param $targetYm string 対象年月
      * @return \Cake\Database\StatementInterface
      */
-    public function removeAllByTargetYm($targetYm)
+    public function reset($storeId, $targetYm)
     {
         return $this->query()
             ->update()
             ->set(['is_deleted' => true])
+            ->where(['store_id' => $storeId])
             ->where(['target_ym' => $targetYm])
             ->execute();
     }

--- a/webapps/webroot/css/FixedShiftTables/prepare.css
+++ b/webapps/webroot/css/FixedShiftTables/prepare.css
@@ -1,11 +1,7 @@
 /** 確定シフト PDF作成時の元HTML */
 
 body, html, #contents {
-    /**
-     * この幅は、28日分のデータに合わせてあります.
-     * 28日以降に日付がある場合も、28日のセルにborderがうまく重なる大きさです.
-     */
-    min-width: 1294px;
+    width: 100%;
 }
 .fc-timeline-event .fc-content {
     white-space: pre-line;
@@ -14,7 +10,7 @@ div {
     overflow: visible !important;
 }
 #fix-shift-table {
-    width: 100%;
+    min-width: 1425px;
 }
 .fc-time-area col {
     min-width: 3em;

--- a/webapps/webroot/css/FixedShiftTables/prepare.css
+++ b/webapps/webroot/css/FixedShiftTables/prepare.css
@@ -1,7 +1,11 @@
 /** 確定シフト PDF作成時の元HTML */
 
 body, html, #contents {
-    width: 100%;
+    /**
+     * この幅は、28日分のデータに合わせてあります.
+     * 28日以降に日付がある場合も、28日のセルにborderがうまく重なる大きさです.
+     */
+    min-width: 1294px;
 }
 .fc-timeline-event .fc-content {
     white-space: pre-line;
@@ -10,7 +14,7 @@ div {
     overflow: visible !important;
 }
 #fix-shift-table {
-    min-width: 1425px;
+    width: 100%;
 }
 .fc-time-area col {
     min-width: 3em;


### PR DESCRIPTION
・削除フラグを立てる時の条件に店舗IDを追加

・PDF見た目調整を行おうとしたが、30日の月でレイアウトが崩れるなどがあったため、
　一度コミットを取り消し